### PR TITLE
単語の一致かどうかを、指定した単語の前方一致で検知するようにした

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,25 +1,26 @@
 
 /* --- 前方一致で検知させる単語・ORで付け加える単語を定義(あらかじめ小文字で定義) --- */
-const TAG_WORD_INDEXOF_TABLE = ["ソフトウェアトーク", "ボイチェビ", "ボイチェビトーク"];
-const TAG_WORD_ADDWORD_TABLE = ["ソフトウェアトーク", "ボイチェビ", "ボイチェビトーク", "voiceroid", "ボイスロイド", "ボイロ", "cevio", "cevio_ai", "a.i.voice", "voicebox", "coefont"];
+const TAG_WORD_INDEXOF_ARRAY = ["ソフトウェアトーク", "ボイチェビ", "ボイチェビトーク"];
+const TAG_WORD_ADDWORD_ARRAY = ["ソフトウェアトーク", "ボイチェビ", "ボイチェビトーク", "voiceroid", "ボイスロイド", "ボイロ", "cevio", "cevio_ai", "a.i.voice", "voicebox", "coefont"];
 
 /* カウンターとか */
 let is_match = false; //前方一致するかどうか
-let try_counter = 0;
+let try_counter = 0; //ORがいくつあるか）
 
 //URL取得してタグの部分だけ良い感じに抜き出す
 // "/tag/ソフトウェアトーク" みたいな感じに取得されるから、/tag/を空白に置換している
 var url_path = location.pathname;
 var tag = decodeURI(url_path.replace("/tag/", ""));
 
+//ORの数を数える
 var ORcount = tag.match(/OR/g);
 if(ORcount){
     try_counter = ORcount.length;
 }
 
 /* --- 前方一致のテーブルを舐め回す --- */
-for (var n = 0; n < TAG_WORD_INDEXOF_TABLE.length; n++) {
-    var tagname = TAG_WORD_INDEXOF_TABLE[n];
+for (var n = 0; n < TAG_WORD_INDEXOF_ARRAY.length; n++) {
+    var tagname = TAG_WORD_INDEXOF_ARRAY[n];
     /* --- 前方一致したら --- */
     if (tag.startsWith(tagname)) {
         is_match = true;
@@ -30,8 +31,10 @@ for (var n = 0; n < TAG_WORD_INDEXOF_TABLE.length; n++) {
 
 //undefinedが文字列として出力されないようにする
 if (genre == undefined) genre = "";
-var url_path = TAG_WORD_ADDWORD_TABLE.join(genre + '+OR+') + genre;
+var url_path = TAG_WORD_ADDWORD_ARRAY.join(genre + '+OR+') + genre;
 
+//前方一致し、ORが7個以下のときに実行
+//ORの上限をつけないと無限に実行してしまうため
 if (is_match && (try_counter < 7)) {
     var url = "https://www.nicovideo.jp/tag/" + encodeURI(url_path)
     location.href = url

--- a/content.js
+++ b/content.js
@@ -1,11 +1,18 @@
 
 /* --- 前方一致で検知させる単語・ORで付け加える単語を定義(あらかじめ小文字で定義) --- */
-const TAG_WORD_INDEXOF_ARRAY = ["ソフトウェアトーク", "ボイチェビ", "ボイチェビトーク"];
-const TAG_WORD_ADDWORD_ARRAY = ["ソフトウェアトーク", "ボイチェビ", "ボイチェビトーク", "voiceroid", "ボイスロイド", "ボイロ", "cevio", "cevio_ai", "a.i.voice", "voicebox", "coefont"];
+const TAG_WORD_INDEXOF_TABLE = [
+    ["ソフトウェアトーク", "ボイチェビ", "ボイチェビトーク"],
+    ["ソフトウェアシンガー", "vocaloid"]
+];
+const TAG_WORD_ADDWORD_TABLE = [
+    ["ソフトウェアトーク", "ボイチェビ", "ボイチェビトーク", "voiceroid", "ボイスロイド", "ボイロ", "cevio", "cevio_ai", "a.i.voice", "voicebox"],
+    ["ソフトウェアシンガー", "vocaloid", "ボカロ", "utau", "cevio", "synthv", "synthesizerv", "neutrino", "歌うボイスロイド"]
+];
+
 
 /* カウンターとか */
 let is_match = false; //前方一致するかどうか
-let try_counter = 0; //ORがいくつあるか）
+let table_col; //前方一致したときのテーブル列
 
 //URL取得してタグの部分だけ良い感じに抜き出す
 // "/tag/ソフトウェアトーク" みたいな感じに取得されるから、/tag/を空白に置換している
@@ -14,28 +21,39 @@ var tag = decodeURI(url_path.replace("/tag/", ""));
 
 //ORの数を数える
 var ORcount = tag.match(/OR/g);
-if(ORcount){
-    try_counter = ORcount.length;
-}
 
 /* --- 前方一致のテーブルを舐め回す --- */
-for (var n = 0; n < TAG_WORD_INDEXOF_ARRAY.length; n++) {
-    var tagname = TAG_WORD_INDEXOF_ARRAY[n];
+for (var n = 0; n < TAG_WORD_INDEXOF_TABLE.length; n++) {
+    //とりあえず配列を代入
+    var tagname_arr = TAG_WORD_INDEXOF_TABLE[n];
+
+    //タグを小文字化
+    tag = tag.toLowerCase();
+
+    //前方一致するものを探す
+    var match_tagname = tagname_arr.find(el => tag.startsWith(el));
+    console.log(match_tagname);
+    console.log(tag)
+
     /* --- 前方一致したら --- */
-    if (tag.startsWith(tagname)) {
+    if (match_tagname) {
         is_match = true;
         /* --- 前方一致箇所を抜いた文字列を取得 ex:ソフトウェアトーク劇場 → 劇場 --- */
-        var genre = tag.replace(tagname, "");
+        var genre = tag.replace(match_tagname, "");
+        table_col = n;
     }
 }
 
 //undefinedが文字列として出力されないようにする
 if (genre == undefined) genre = "";
-var url_path = TAG_WORD_ADDWORD_ARRAY.join(genre + '+OR+') + genre;
+//ORが無限に出ないようにする
+if (genre.match(/OR/g)) genre = genre.substr(0, genre.indexOf("+OR"));
 
-//前方一致し、ORが7個以下のときに実行
-//ORの上限をつけないと無限に実行してしまうため
-if (is_match && (try_counter < 7)) {
+//ジャンルを追記しながらURLにする
+url_path = TAG_WORD_ADDWORD_TABLE[table_col].join(genre + '+OR+') + genre;
+
+//前方一致し、入力文字列にORが無い時に実行
+if (is_match && (!ORcount)) {
     var url = "https://www.nicovideo.jp/tag/" + encodeURI(url_path)
     location.href = url
 }

--- a/content.js
+++ b/content.js
@@ -1,4 +1,3 @@
-
 /* --- 前方一致で検知させる単語・ORで付け加える単語を定義(あらかじめ小文字で定義) --- */
 const TAG_WORD_INDEXOF_TABLE = [
     ["ソフトウェアトーク", "ボイチェビ", "ボイチェビトーク"],
@@ -10,16 +9,16 @@ const TAG_WORD_ADDWORD_TABLE = [
 ];
 
 
-/* カウンターとか */
+/* --- カウンターとかの事前定義 --- */
 let is_match = false; //前方一致するかどうか
 let table_col; //前方一致したときのテーブル列
 
-//URL取得してタグの部分だけ良い感じに抜き出す
+/* --- カURL取得してタグの部分だけ良い感じに抜き出す --- */
 // "/tag/ソフトウェアトーク" みたいな感じに取得されるから、/tag/を空白に置換している
 var url_path = location.pathname;
 var tag = decodeURI(url_path.replace("/tag/", ""));
 
-//ORの数を数える
+/* --- ORの数を数える --- */
 var ORcount = tag.match(/OR/g);
 
 /* --- 前方一致のテーブルを舐め回す --- */
@@ -32,8 +31,6 @@ for (var n = 0; n < TAG_WORD_INDEXOF_TABLE.length; n++) {
 
     //前方一致するものを探す
     var match_tagname = tagname_arr.find(el => tag.startsWith(el));
-    console.log(match_tagname);
-    console.log(tag)
 
     /* --- 前方一致したら --- */
     if (match_tagname) {
@@ -57,4 +54,3 @@ if (is_match && (!ORcount)) {
     var url = "https://www.nicovideo.jp/tag/" + encodeURI(url_path)
     location.href = url
 }
-

--- a/content.js
+++ b/content.js
@@ -1,41 +1,39 @@
 
-//動画の最初に言ってた対応表みたいなやつ
-//自由に列も中の単語も編集しちゃって大丈夫(ニコ動の仕様上OR検索は最大10件なんで行は最大10個かも)
-const TAGNAME_TABLE = [
-    ["ソフトウェアトーク", "VOICEROID", "ボイスロイド", "CeVIO","a.i.voice","VOICEVOX"],
-    ["ソフトウェアトーク実況プレイ", "VOICEROID実況プレイ","CeVIO実況プレイ","a.i.voice実況プレイ"],
-    ["ソフトウェアトーク劇場", "VOICEROID劇場","CeVIO劇場","A.I.VOICE劇場"],
-    ["ソフトウェアトーク解説", "VOICEROID解説","CeVIO解説"],
-    ["ソフトウェアトークキッチン", "VOICEROIDキッチン","CeVIOキッチン"],
-    ["ソフトウェアトーク車載", "VOICEROID車載","CeVIO車載"],
-    ["CeVIO_AI","CeVIO"],
-    [],
-    [],
-    []
-]
+/* --- 前方一致で検知させる単語・ORで付け加える単語を定義(あらかじめ小文字で定義) --- */
+const TAG_WORD_INDEXOF_TABLE = ["ソフトウェアトーク", "ボイチェビ", "ボイチェビトーク"];
+const TAG_WORD_ADDWORD_TABLE = ["ソフトウェアトーク", "ボイチェビ", "ボイチェビトーク", "voiceroid", "ボイスロイド", "ボイロ", "cevio", "cevio_ai", "a.i.voice", "voicebox", "coefont"];
+
+/* カウンターとか */
+let is_match = false; //前方一致するかどうか
+let try_counter = 0;
 
 //URL取得してタグの部分だけ良い感じに抜き出す
 // "/tag/ソフトウェアトーク" みたいな感じに取得されるから、/tag/を空白に置換している
-var url_path = location.pathname
-var tag_name = decodeURI(url_path.replace("/tag/",""))
+var url_path = location.pathname;
+var tag = decodeURI(url_path.replace("/tag/", ""));
 
-//テーブルを上から1行ずつ舐め回す
-for(let n = 0; n < TAGNAME_TABLE.length; n++){
-    //行をいったん変数に格納
-    tagname_array = TAGNAME_TABLE[n]
+var ORcount = tag.match(/OR/g);
+if(ORcount){
+    try_counter = ORcount.length;
+}
 
-    //比較用に小文字化したものを変数に格納
-    comvarsion_tag = tag_name.toLowerCase()
-    comversion_array = tagname_array.map(v => v.toLowerCase())
-
-    //行の中にタグの単語が存在してた場合、{ }で囲まれた部分の処理をする
-    if (comversion_array.includes(comvarsion_tag)) {
-        //["VOICEROID","CeVIO"] → "VOICEROID OR CeVIO" みたいな変換する
-        var converted_tag = tagname_array.join(" OR ")
-
-        //良い感じにURL作って飛ばす、こわい
-        var url = "https://www.nicovideo.jp/tag/" + encodeURI(converted_tag)
-        location.href = url
-        break;
+/* --- 前方一致のテーブルを舐め回す --- */
+for (var n = 0; n < TAG_WORD_INDEXOF_TABLE.length; n++) {
+    var tagname = TAG_WORD_INDEXOF_TABLE[n];
+    /* --- 前方一致したら --- */
+    if (tag.startsWith(tagname)) {
+        is_match = true;
+        /* --- 前方一致箇所を抜いた文字列を取得 ex:ソフトウェアトーク劇場 → 劇場 --- */
+        var genre = tag.replace(tagname, "");
     }
 }
+
+//undefinedが文字列として出力されないようにする
+if (genre == undefined) genre = "";
+var url_path = TAG_WORD_ADDWORD_TABLE.join(genre + '+OR+') + genre;
+
+if (is_match && (try_counter < 7)) {
+    var url = "https://www.nicovideo.jp/tag/" + encodeURI(url_path)
+    location.href = url
+}
+

--- a/webRequestAPI/background.js
+++ b/webRequestAPI/background.js
@@ -36,8 +36,6 @@ browser.webRequest.onBeforeRequest.addListener(details => {
 
         //前方一致するものを探す
         var match_tagname = tagname_arr.find(el => tag.startsWith(el));
-        console.log(match_tagname);
-        console.log(tag)
 
         /* --- 前方一致したら --- */
         if (match_tagname) {
@@ -48,7 +46,7 @@ browser.webRequest.onBeforeRequest.addListener(details => {
         }
     }
 
-     //前方一致・ORが5個以下なら実行 
+     //前方一致・ORないなら
     if (is_match && (!ORcount)) {
         //undefinedが文字列として出力されないようにする
         if (genre == undefined) genre = "";

--- a/webRequestAPI/background.js
+++ b/webRequestAPI/background.js
@@ -19,7 +19,7 @@ browser.webRequest.onBeforeRequest.addListener(details => {
 
     //ORの数を数える
     var ORcount = tag.match(/OR/g);
-    if(ORcount){
+    if (ORcount) {
         try_counter = ORcount.length;
     }
 
@@ -34,22 +34,22 @@ browser.webRequest.onBeforeRequest.addListener(details => {
         }
     }
 
-        //undefinedが文字列として出力されないようにする
-        if (genre == undefined) genre = "";
-        //ORが無限に出ないようにする
-        if (genre.match(/OR/g)) genre = genre.substr(0, genre.indexOf("+OR"));
+    //undefinedが文字列として出力されないようにする
+    if (genre == undefined) genre = "";
+    //ORが無限に出ないようにする
+    if (genre.match(/OR/g)) genre = genre.substr(0, genre.indexOf("+OR"));
 
-        //ジャンルを追記しながらURLにする
-        url_path = TAG_WORD_ADDWORD_ARRAY.join(genre + '+OR+') + genre;
+    //ジャンルを追記しながらURLにする
+    url_path = TAG_WORD_ADDWORD_ARRAY.join(genre + '+OR+') + genre;
 
     //前方一致・ORが5個以下なら実行 
     if (is_match && ORcount < 5) {
         url.pathname = '/tag/' + url_path;
-        return {redirectUrl : url.href};
+        return { redirectUrl: url.href };
     }
     is_match = false;
 
     return {};
 }, {
-    urls : ['*://www.nicovideo.jp/tag/*']
+    urls: ['*://www.nicovideo.jp/tag/*']
 }, ['blocking']);

--- a/webRequestAPI/background.js
+++ b/webRequestAPI/background.js
@@ -2,23 +2,14 @@
 /* --- ブラウザの違いを吸収 --- */
 if (typeof browser === 'undefined') browser = chrome;
 
+/* --- 前方一致で検知させる単語・ORで付け加える単語を定義(あらかじめ小文字で定義) --- */
+const TAG_WORD_INDEXOF_ARRAY = ["ソフトウェアトーク", "ボイチェビ", "ボイチェビトーク"];
+const TAG_WORD_ADDWORD_ARRAY = ["ソフトウェアトーク", "ボイチェビ", "ボイチェビトーク", "voiceroid", "ボイスロイド", "ボイロ", "cevio", "cevio_ai", "a.i.voice", "voicebox"];
 
-/* --- 検知して並べるタグたちを定義(あらかじめ小文字で定義) --- */
-const TAGNAME_TABLE = [
-    ["ソフトウェアトーク", "ボイチェビトーク", "voiceroid", "ボイスロイド", "cevio","a.i.voice","voicevox"],
-    ["ソフトウェアトーク実況プレイ", "ボイチェビトーク実況プレイ", "voiceroid実況プレイ","cevio実況プレイ","a.i.voice実況プレイ"],
-    ["ソフトウェアトーク劇場", "ボイチェビトーク劇場", "voiceroid劇場","cevio劇場","a.i.voice劇場"],
-    ["ソフトウェアトーク解説", "ボイチェビトーク解説", "voiceroid解説","cevio解説"],
-    ["ソフトウェアトークキッチン", "ボイチェビトークキッチン", "voiceroidキッチン","cevioキッチン"],
-    ["ソフトウェアトーク車載", "ボイチェビトーク車載", "voiceroid車載","cevio車載"],
-    ["ボイチェビトーク", "ソフトウェアトーク", "voiceroid", "ボイスロイド", "cevio","a.i.voice","voicevox"],
-    ["ボイチェビトーク実況プレイ", "ソフトウェアトーク実況プレイ", "voiceroid実況プレイ","cevio実況プレイ","a.i.voice実況プレイ"],
-    ["ボイチェビトーク劇場", "ソフトウェアトーク劇場", "voiceroid劇場","cevio劇場","a.i.voice劇場"],
-    ["ボイチェビトーク解説", "ソフトウェアトーク解説", "voiceroid解説","cevio解説"],
-    ["ボイチェビトークキッチン", "ソフトウェアトークキッチン", "voiceroidキッチン","cevioキッチン"],
-    ["ボイチェビトーク車載", "ソフトウェアトーク車載", "voiceroid車載","cevio車載"],
-    ["cevio_ai","cevio"]
-];
+/* カウンターとか */
+let is_match = false; //前方一致するかどうか
+let try_counter = 0; //ORがいくつあるか）
+let url_path; //複数回動いてほしくないので事前定義
 
 
 /* --- リクエストが送信される前にリダイレクトをかける --- */
@@ -26,13 +17,32 @@ browser.webRequest.onBeforeRequest.addListener(details => {
     /* タグ名を取得 */
     let url = new URL(details.url);
     let tag = decodeURI(url.pathname.split('/').filter(text => text.length > 0).pop());
-    /* タグをテーブルから検索 */
-    let tag_names = TAGNAME_TABLE.filter(row => row.indexOf(tag.toLowerCase()) === 0);
-    if (tag_names.length === 1) {
-        /* タグリストが見つかれば */
-        url.pathname = '/tag/' + tag_names[0].join('+OR+');
+
+    /* --- 前方一致のテーブルを舐め回す --- */
+    for (var n = 0; n < TAG_WORD_INDEXOF_ARRAY.length; n++) {
+        var tagname = TAG_WORD_INDEXOF_ARRAY[n];
+        /* --- 前方一致したら --- */
+        if (tag.startsWith(tagname)) {
+            is_match = true;
+            /* --- 前方一致箇所を抜いた文字列を取得 ex:ソフトウェアトーク劇場 → 劇場 --- */
+            var genre = tag.replace(tagname, "");
+        }
+    }
+
+    //undefinedが文字列として出力されないようにする
+    if (genre == undefined) genre = "";
+    //ORが無限に出ないようにする
+    if (genre.match(/OR/g)) genre = genre.substr(0, genre.indexOf("+OR"));
+
+    //ジャンルを追記しながらURLにする
+    url_path = TAG_WORD_ADDWORD_ARRAY.join(genre + '+OR+') + genre;
+
+    //前方一致していたら実行
+    if (is_match) {
+        url.pathname = '/tag/' + url_path;
         return {redirectUrl : url.href};
     }
+
     return {};
 }, {
     urls : ['*://www.nicovideo.jp/tag/*']

--- a/webRequestAPI/background.js
+++ b/webRequestAPI/background.js
@@ -3,12 +3,18 @@
 if (typeof browser === 'undefined') browser = chrome;
 
 /* --- 前方一致で検知させる単語・ORで付け加える単語を定義(あらかじめ小文字で定義) --- */
-const TAG_WORD_INDEXOF_ARRAY = ["ソフトウェアトーク", "ボイチェビ", "ボイチェビトーク"];
-const TAG_WORD_ADDWORD_ARRAY = ["ソフトウェアトーク", "ボイチェビ", "ボイチェビトーク", "voiceroid", "ボイスロイド", "ボイロ", "cevio", "cevio_ai", "a.i.voice", "voicebox"];
+const TAG_WORD_INDEXOF_TABLE = [
+    ["ソフトウェアトーク", "ボイチェビ", "ボイチェビトーク"],
+    ["ソフトウェアシンガー", "vocaloid"]
+];
+const TAG_WORD_ADDWORD_TABLE = [
+    ["ソフトウェアトーク", "ボイチェビ", "ボイチェビトーク", "voiceroid", "ボイスロイド", "ボイロ", "cevio", "cevio_ai", "a.i.voice", "voicebox"],
+    ["ソフトウェアシンガー", "vocaloid", "ボカロ", "utau", "cevio", "synthv", "synthesizerv", "neutrino", "歌うボイスロイド"]
+];
 
 /* カウンターとか */
 let is_match = false; //前方一致するかどうか
-let try_counter = 0; //ORがいくつあるか）
+let table_col; //前方一致したときのテーブル列
 let url_path; //複数回動いてほしくないので事前定義
 
 /* --- リクエストが送信される前にリダイレクトをかける --- */
@@ -19,31 +25,40 @@ browser.webRequest.onBeforeRequest.addListener(details => {
 
     //ORの数を数える
     var ORcount = tag.match(/OR/g);
-    if (ORcount) {
-        try_counter = ORcount.length;
-    }
 
     /* --- 前方一致のテーブルを舐め回す --- */
-    for (var n = 0; n < TAG_WORD_INDEXOF_ARRAY.length; n++) {
-        var tagname = TAG_WORD_INDEXOF_ARRAY[n];
+    for (var n = 0; n < TAG_WORD_INDEXOF_TABLE.length; n++) {
+        //とりあえず配列を代入
+        var tagname_arr = TAG_WORD_INDEXOF_TABLE[n];
+
+        //タグを小文字化
+        tag = tag.toLowerCase();
+
+        //前方一致するものを探す
+        var match_tagname = tagname_arr.find(el => tag.startsWith(el));
+        console.log(match_tagname);
+        console.log(tag)
+
         /* --- 前方一致したら --- */
-        if (tag.startsWith(tagname)) {
+        if (match_tagname) {
             is_match = true;
             /* --- 前方一致箇所を抜いた文字列を取得 ex:ソフトウェアトーク劇場 → 劇場 --- */
-            var genre = tag.replace(tagname, "");
+            var genre = tag.replace(match_tagname, "");
+            table_col = n;
         }
     }
 
-    //undefinedが文字列として出力されないようにする
-    if (genre == undefined) genre = "";
-    //ORが無限に出ないようにする
-    if (genre.match(/OR/g)) genre = genre.substr(0, genre.indexOf("+OR"));
+     //前方一致・ORが5個以下なら実行 
+    if (is_match && (!ORcount)) {
+        //undefinedが文字列として出力されないようにする
+        if (genre == undefined) genre = "";
+        //ORが無限に出ないようにする
+        if (genre.match(/OR/g)) genre = genre.substr(0, genre.indexOf("+OR"));
 
-    //ジャンルを追記しながらURLにする
-    url_path = TAG_WORD_ADDWORD_ARRAY.join(genre + '+OR+') + genre;
+        //ジャンルを追記しながらURLにする
+        url_path = TAG_WORD_ADDWORD_TABLE[table_col].join(genre + '+OR+') + genre;
 
-    //前方一致・ORが5個以下なら実行 
-    if (is_match && ORcount < 5) {
+        //リダイレクト
         url.pathname = '/tag/' + url_path;
         return { redirectUrl: url.href };
     }


### PR DESCRIPTION
> これから皆様に作っていただきます

とのことだったので、いい感じに修正してみました！
どっちいじればいいか分かんなかったので、通常のスクリプトも、API利用版のスクリプトもどちらも修正しています。

## 変更点
### 単語の一致かどうかを、単語の前方一致で検知するようにしました
現状のものは、対応するタグをすべて記述しないといけない状態でした。
ボイロ界隈のジャンルをすべて網羅して書き込むのは ~面倒なので~ 手間をかけて愛情を注ぎ込む必要があるので、
主要単語を前方一致で判断し、後ろに追加の文言をくっつける形にしました。

例
* ソフトウェアトーク劇場／VOICEROID劇場　→主要単語の後ろの「劇場」部分が一致
* VOCALOIDカバー曲／UTAUカバー曲　→主要単語の後ろの「カバー曲」部分が一致

といったふうに、ボイロ／ボカロ界隈の大半が前半部分が変わり、後半部分が同じものになっている事が多いです。
なのでこうしました

```md
## 例：入力文字「ソフトウェアトーク劇場」の場合
1. 前方一致で「ソフトウェアトーク」を検出
2. 入力文字「ソフトウェアトーク劇場」から「劇場」部分のみ取得
3. 置き換える単語「ボイチェビトーク, voiceroid, cevio など」の後ろに「劇場」と「+OR+」をくっつけてURLを投げる
```

#### 詳細
* 定義テーブルを、検知させる単語と置き換える単語に分離しました。テーブルの列で同じものが読み込まれるようになっています。（検出単語が2列目の場合、置き換えが2列目になる）

```js
/* --- 前方一致で検知させる単語・ORで付け加える単語を定義(あらかじめ小文字で定義) --- */
const TAG_WORD_INDEXOF_TABLE = [
    ["ソフトウェアトーク", "ボイチェビ", "ボイチェビトーク"],
    ["ソフトウェアシンガー", "vocaloid"]
];
const TAG_WORD_ADDWORD_TABLE = [
    ["ソフトウェアトーク", "ボイチェビ", "ボイチェビトーク", "voiceroid", "ボイスロイド", "ボイロ", "cevio", "cevio_ai", "a.i.voice", "voicebox"],
    ["ソフトウェアシンガー", "vocaloid", "ボカロ", "utau", "cevio", "synthv", "synthesizerv", "neutrino", "歌うボイスロイド"]
];

```

* 入力文字列（検索欄に手動で入れた文字）にORが含まれる場合は動作させないようにしました。
現状のこの仕組だと、ORが置き換え単語分増え続けてしまうので・・・。何かいい方法があれば...

```
例
　入力文字：VOICEROID劇場 OR ゲーム
　ORが入ってしまうと：ソフトウェアトーク劇場 OR ゲーム OR ボイチェビ劇場 OR ゲーム OR  ・・・となってしまう
　現状実装：VOICEROID劇場 OR ゲームの結果を表示します（スクリプトが動作しないようにしました）
```

```js
var ORcount = tag.match(/OR/g);

.
. 略
.

if (is_match && (!ORcount)) {
        //undefinedが文字列として出力されないようにする
        if (genre == undefined) genre = "";
        //ORが無限に出ないようにする
        if (genre.match(/OR/g)) genre = genre.substr(0, genre.indexOf("+OR"));

        //ジャンルを追記しながらURLにする
        url_path = TAG_WORD_ADDWORD_TABLE[table_col].join(genre + '+OR+') + genre;

        //リダイレクト
        url.pathname = '/tag/' + url_path;
        return { redirectUrl: url.href };
    }
```

あとはソースを見れば多分分かると思います。

---
### 補足
* おまけデータ（VOCALOID関連のタグ分散問題の対応データ）を入れました。追加するときはこんな感じで書き連ねていってもらえればいけるとおもいます。
* 前方一致で対応できる単語（〇〇劇場／〇〇実況Part1リンク など）は楽にできるようになると思いますが、それ以外「歌うVOICEROID」と「歌うボイスロイド」と「歌うA.I.VOICE」などのように前方一致じゃ対応できない単語は、これまで通りすべて登録していく必要があります。

---

修正という名の改変に近いカタチになってしまいました。すみません...
マージするかどうかはお任せします
